### PR TITLE
use the contentdir yum variable

### DIFF
--- a/CentOS-Ceph-Luminous.repo
+++ b/CentOS-Ceph-Luminous.repo
@@ -5,7 +5,7 @@
 
 [centos-ceph-luminous]
 name=CentOS-$releasever - Ceph Luminous
-baseurl=http://mirror.centos.org/centos/$releasever/storage/$basearch/ceph-luminous/
+baseurl=http://mirror.centos.org/$contentdir/$releasever/storage/$basearch/ceph-luminous/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage
@@ -19,14 +19,14 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage
 
 [centos-ceph-luminous-debuginfo]
 name=CentOS-$releasever - Ceph Luminous DebugInfo
-baseurl=http://debuginfo.centos.org/centos/$releasever/storage/$basearch/ceph-luminous/
+baseurl=http://debuginfo.centos.org/$contentdir/$releasever/storage/$basearch/ceph-luminous/
 gpgcheck=0
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage
 
 [centos-ceph-luminous-source]
 name=CentOS-$releasever - Ceph Luminous Source
-baseurl=http://vault.centos.org/centos/$releasever/storage/Source/ceph-luminous/
+baseurl=http://vault.centos.org/$contentdir/$releasever/storage/Source/ceph-luminous/
 gpgcheck=0
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Storage

--- a/centos-release-ceph-luminous.spec
+++ b/centos-release-ceph-luminous.spec
@@ -1,6 +1,6 @@
 Summary: Ceph Luminous packages from the CentOS Storage SIG repository
 Name: centos-release-ceph-luminous
-Version: 1.0
+Version: 1.1
 Release: 1%{?dist}
 License: GPLv2
 URL: http://wiki.centos.org/SpecialInterestGroup/Storage
@@ -27,5 +27,9 @@ install -D -m 644 %{SOURCE0} %{buildroot}%{_sysconfdir}/yum.repos.d/CentOS-Ceph-
 %config(noreplace) %{_sysconfdir}/yum.repos.d/CentOS-Ceph-Luminous.repo
 
 %changelog
+* Fri Jul 06 2018 Brian Stinson <brian@bstinson.com> - 1.1-1
+- Update to use the $contentdir variable to point at centos for x86_64 and
+  altarch for the other arches
+
 * Wed Sep 20 2017 Giulio Fidente <gfidente@fedoraproject.org> - 1.0-1
 - Initial version based on Jewel.


### PR DESCRIPTION
which separates altarch content from primary architecture content.

We need to wait to merge this until the signing process syncs content to the altarch location on the mirrors. We should be able to use this to test x86_64 in the meantime.